### PR TITLE
Partial back swipe does not pop last view controller from stack

### DIFF
--- a/Sources/ComposableNavigation/StackNavigation/StackNavigationHandler.swift
+++ b/Sources/ComposableNavigation/StackNavigation/StackNavigationHandler.swift
@@ -108,6 +108,7 @@ public class StackNavigationHandler<ViewProvider: ViewProviding>: NSObject, UINa
 	) {
 		guard
 			let transition = navigationController.transitionCoordinator,
+            !transition.isCancelled,
 			let fromViewController = transition.viewController(forKey: .from),
 			let toViewController = transition.viewController(forKey: .to)
 		else {


### PR DESCRIPTION
Fixing issue reported in [Incorrect Navigation Stack Update on Canceled Swipe Back Gesture](https://github.com/heinzl/swift-composable-navigation/issues/17)

This issue is specific to iOS version 18+