### PR TITLE
Migrate to Swift 6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Run tests
@@ -29,7 +29,7 @@ jobs:
               -derivedDataPath DerivedData \
               -clonedSourcePackagesDirPath ClonedSourcePackages \
               -enableCodeCoverage YES \
-              -destination 'platform=iOS Simulator,name=iPhone 15' \
+              -destination 'platform=iOS Simulator,name=iPhone 17' \
               | xcpretty --report junit --output test_report.xml
       - name: Extract code coverage
         run: |

--- a/Examples/ComposableNavigation-Examples/ComposableNavigation-Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/ComposableNavigation-Examples/ComposableNavigation-Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "e28911721538fa0c2439e92320bad13e3200866f",
-        "version" : "2.2.3"
+        "revision" : "ae208d1a5cf33aee1d43734ea780a09ada6e2a21",
+        "version" : "2.3.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
-        "version" : "1.0.0"
+        "revision" : "fd16d76fd8b9a976d88bfb6cacc05ca8d19c91b6",
+        "version" : "1.1.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "b871e5ed11a23e52c2896a92ce2c829982ff8619",
-        "version" : "1.4.2"
+        "revision" : "6989976265be3f8d2b5802c722f9ba168e227c71",
+        "version" : "1.7.2"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "a8421d68068d8f45fbceb418fbf22c5dad4afd33",
-        "version" : "1.0.2"
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "1f952d8c69ace5e53bb69a218e6ed00e03a4695c",
-        "version" : "1.11.2"
+        "revision" : "5b0890fabfd68a2d375d68502bc3f54a8548c494",
+        "version" : "1.23.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
-        "version" : "1.1.0"
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-        "version" : "1.3.0"
+        "revision" : "2a2a938798236b8fa0bc57c453ee9de9f9ec3ab0",
+        "version" : "1.4.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "00bc30ca03f98881329fab7f1bebef8eba472596",
-        "version" : "1.3.1"
+        "revision" : "c79f72b3e67a1eb64f66f76704c22ed6a5c1ed84",
+        "version" : "1.11.0"
       }
     },
     {
@@ -82,30 +82,39 @@
       }
     },
     {
+      "identity" : "swift-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
+      "state" : {
+        "revision" : "bf498690e1f6b4af790260f542e8428a4ba10d78",
+        "version" : "2.6.0"
+      }
+    },
+    {
       "identity" : "swift-perception",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "d3ab98dc2887d1cc3bed676f6fa354da4cb22b3c",
-        "version" : "1.2.4"
+        "revision" : "4f47ebafed5f0b0172cf5c661454fa8e28fb2ac4",
+        "version" : "2.0.9"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "3bfc408cc2d0bee2287c174da6b1c76768377818",
+        "version" : "2.7.4"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
         "version" : "510.0.2"
-      }
-    },
-    {
-      "identity" : "swiftui-navigation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swiftui-navigation",
-      "state" : {
-        "revision" : "b7c9a79f6f6b1fefb87d3e5a83a9c2fe7cdc9720",
-        "version" : "1.5.0"
       }
     },
     {
@@ -113,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
-        "version" : "1.1.2"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 
 import PackageDescription
 

--- a/Sources/ComposableNavigation/ModalNavigation/ModalNavigation.swift
+++ b/Sources/ComposableNavigation/ModalNavigation/ModalNavigation.swift
@@ -3,8 +3,10 @@ import ComposableArchitecture
 
 /// `ModalNavigation` models state and actions of a commonly used modal view presentation.
 /// Views can be presented with a certain style and dismissed.
-public struct ModalNavigation<Item: Equatable>: Reducer {
-	public init() {}
+public struct ModalNavigation<Item: Equatable>: Reducer
+    where Item: SendableMetatype {
+	
+    public init() {}
 	
 	public struct State: Equatable {
 		public var styledItem: StyledItem?
@@ -56,3 +58,7 @@ public struct ModalNavigation<Item: Equatable>: Reducer {
 		}
 	}
 }
+
+extension ModalNavigation.State: Sendable where Item: Sendable { }
+extension ModalNavigation.Action: Sendable where Item: Sendable { }
+extension ModalNavigation.StyledItem: Sendable where Item: Sendable { }

--- a/Sources/ComposableNavigation/ModalNavigation/ModalNavigationHandler.swift
+++ b/Sources/ComposableNavigation/ModalNavigation/ModalNavigationHandler.swift
@@ -8,8 +8,10 @@ import ComposableArchitecture
 /// Additionally, it acts as the `UIAdaptivePresentationControllerDelegate` and automatically updates the state
 /// for pull-to-dismiss for views presented as a sheet.
 @MainActor
-public class ModalNavigationHandler<ViewProvider: ViewProviding>: NSObject, UIAdaptivePresentationControllerDelegate {
-	public typealias Item = ViewProvider.Item
+public class ModalNavigationHandler<ViewProvider: ViewProviding>: NSObject, UIAdaptivePresentationControllerDelegate
+    where ViewProvider.Item: SendableMetatype {
+	
+    public typealias Item = ViewProvider.Item
 	public typealias Navigation = ModalNavigation<Item>
 	
 	internal let viewStore: ViewStore<Navigation.State, Navigation.Action>

--- a/Sources/ComposableNavigation/ModalNavigation/ModalNavigationViewController.swift
+++ b/Sources/ComposableNavigation/ModalNavigation/ModalNavigationViewController.swift
@@ -4,8 +4,10 @@ import ComposableArchitecture
 /// A convenience container view controller intended to decouple the content and modal presented views.
 /// This way the content view can be reused in multiple contexts without
 /// tying the content view's implementation and the navigation logic together.
-public class ModalNavigationViewController<ViewProvider: ViewProviding>: UIViewController {
-	internal let navigationHandler: ModalNavigationHandler<ViewProvider>
+public class ModalNavigationViewController<ViewProvider: ViewProviding>: UIViewController
+    where ViewProvider.Item: SendableMetatype {
+	
+    internal let navigationHandler: ModalNavigationHandler<ViewProvider>
 	
 	public convenience init(
 		contentViewController: UIViewController,

--- a/Sources/ComposableNavigation/StackNavigation/StackNavigation.swift
+++ b/Sources/ComposableNavigation/StackNavigation/StackNavigation.swift
@@ -3,8 +3,10 @@ import OrderedCollections
 
 /// `StackNavigation` models state and actions of a stack-based scheme for navigating hierarchical content.
 /// Views can be pushed on the stack or popped from the stack. Even mutations to the whole stack can be performed.
-public struct StackNavigation<Item: Equatable>: Reducer {
-	public init() {}
+public struct StackNavigation<Item: Equatable>: Reducer
+    where Item: SendableMetatype {
+	
+    public init() {}
 	
 	public struct State: Equatable {
 		public var items: [Item]
@@ -64,3 +66,6 @@ public struct StackNavigation<Item: Equatable>: Reducer {
 		state.areAnimationsEnabled = animated
 	}
 }
+
+extension StackNavigation.State: Sendable where Item: Sendable { }
+extension StackNavigation.Action: Sendable where Item: Sendable { }

--- a/Sources/ComposableNavigation/StackNavigation/StackNavigationHandler.swift
+++ b/Sources/ComposableNavigation/StackNavigation/StackNavigationHandler.swift
@@ -7,8 +7,10 @@ import OrderedCollections
 ///
 /// It also supports automatic state updates for popping items via the leading-edge swipe gesture or the long press back-button menu.
 @MainActor
-public class StackNavigationHandler<ViewProvider: ViewProviding>: NSObject, UINavigationControllerDelegate {
-	public typealias Item = ViewProvider.Item
+public class StackNavigationHandler<ViewProvider: ViewProviding>: NSObject, UINavigationControllerDelegate
+    where ViewProvider.Item: SendableMetatype {
+	
+    public typealias Item = ViewProvider.Item
 	public typealias Navigation = StackNavigation<Item>
 	
 	internal let viewStore: ViewStore<Navigation.State, Navigation.Action>

--- a/Sources/ComposableNavigation/StackNavigation/StackNavigationViewController.swift
+++ b/Sources/ComposableNavigation/StackNavigation/StackNavigationViewController.swift
@@ -2,8 +2,10 @@ import UIKit
 import ComposableArchitecture
 
 /// A convenience UINavigationController implementation containing a `StackNavigationHandler`.
-public class StackNavigationViewController<ViewProvider: ViewProviding>: UINavigationController {
-	internal let navigationHandler: StackNavigationHandler<ViewProvider>
+public class StackNavigationViewController<ViewProvider: ViewProviding>: UINavigationController
+    where ViewProvider.Item: SendableMetatype {
+	
+    internal let navigationHandler: StackNavigationHandler<ViewProvider>
 	
 	public convenience init(
 		store: Store<StackNavigation<ViewProvider.Item>.State, StackNavigation<ViewProvider.Item>.Action>,

--- a/Sources/ComposableNavigation/TabNavigation/TabNavigation.swift
+++ b/Sources/ComposableNavigation/TabNavigation/TabNavigation.swift
@@ -6,8 +6,10 @@ import OrderedCollections
 ///
 /// The active navigation item can be changed by setting a new item. Mutations to the items array
 /// are reflected as well (e.g. changing the tab order).
-public struct TabNavigation<Item: Equatable>: Reducer {
-	public init() {}
+public struct TabNavigation<Item: Equatable>: Reducer
+    where Item: SendableMetatype {
+	
+    public init() {}
 	
 	public struct State: Equatable {
 		public var items: [Item]
@@ -62,3 +64,6 @@ public struct TabNavigation<Item: Equatable>: Reducer {
 		state.activeItem = item
 	}
 }
+
+extension TabNavigation.State: Sendable where Item: Sendable { }
+extension TabNavigation.Action: Sendable where Item: Sendable { }

--- a/Sources/ComposableNavigation/TabNavigation/TabNavigationHandler.swift
+++ b/Sources/ComposableNavigation/TabNavigation/TabNavigationHandler.swift
@@ -8,8 +8,9 @@ import ComposableArchitecture
 /// Additionally, it acts as the `UITabBarControllerDelegate` and automatically updates the state
 /// when the active tab is changed by the user.
 @MainActor
-public class TabNavigationHandler<ViewProvider: ViewProviding>: NSObject, UITabBarControllerDelegate {
-	public typealias Item = ViewProvider.Item
+public class TabNavigationHandler<ViewProvider: ViewProviding>: NSObject, UITabBarControllerDelegate where ViewProvider.Item: SendableMetatype {
+	
+    public typealias Item = ViewProvider.Item
 	public typealias Navigation = TabNavigation<Item>
 	
 	internal let viewStore: ViewStore<Navigation.State, Navigation.Action>

--- a/Sources/ComposableNavigation/TabNavigation/TabNavigationViewController.swift
+++ b/Sources/ComposableNavigation/TabNavigation/TabNavigationViewController.swift
@@ -2,8 +2,10 @@ import UIKit
 import ComposableArchitecture
 
 /// A convenience UITabBarController implementation containing a `TabNavigationHandler`.
-public class TabNavigationViewController<ViewProvider: ViewProviding>: UITabBarController {
-	internal let navigationHandler: TabNavigationHandler<ViewProvider>
+public class TabNavigationViewController<ViewProvider: ViewProviding>: UITabBarController
+    where ViewProvider.Item: SendableMetatype {
+	
+    internal let navigationHandler: TabNavigationHandler<ViewProvider>
 	
 	public convenience init(
 		store: Store<TabNavigation<ViewProvider.Item>.State, TabNavigation<ViewProvider.Item>.Action>,

--- a/Sources/ComposableNavigation/Utils/Store+CompactMap.swift
+++ b/Sources/ComposableNavigation/Utils/Store+CompactMap.swift
@@ -4,15 +4,18 @@ public extension Store where State: Equatable {
 	func compactMap<NonOptionalState, Unwrapped>(
 		_ transform: (Store<NonOptionalState, Action>) -> Unwrapped
 	) -> Unwrapped? where State == NonOptionalState? {
-        guard let _ = withState({ $0 }) else {
-            return nil
-        }
-        
-        return transform(
-            scope(
-                state: \.unsafelyUnwrapped,
-                action: \.self
-            )
-        )
+        if var state = self.withState({ $0 }) {
+			return transform(
+				self.scope(
+					state: {
+						state = $0 ?? state
+						return state
+					},
+					action: { $0 }
+				)
+			)
+		} else {
+			return nil
+		}
 	}
 }

--- a/Sources/ComposableNavigation/Utils/Store+CompactMap.swift
+++ b/Sources/ComposableNavigation/Utils/Store+CompactMap.swift
@@ -4,18 +4,15 @@ public extension Store where State: Equatable {
 	func compactMap<NonOptionalState, Unwrapped>(
 		_ transform: (Store<NonOptionalState, Action>) -> Unwrapped
 	) -> Unwrapped? where State == NonOptionalState? {
-		if var state = self.withState({ $0 }) {
-			return transform(
-				self.scope(
-					state: {
-						state = $0 ?? state
-						return state
-					},
-					action: { $0 }
-				)
-			)
-		} else {
-			return nil
-		}
+        guard let _ = withState({ $0 }) else {
+            return nil
+        }
+        
+        return transform(
+            scope(
+                state: \.unsafelyUnwrapped,
+                action: \.self
+            )
+        )
 	}
 }

--- a/Sources/ComposableNavigation/ViewProviding.swift
+++ b/Sources/ComposableNavigation/ViewProviding.swift
@@ -4,6 +4,7 @@ import SwiftUI
 @MainActor
 public protocol ViewProviding {
 	associatedtype Item: Hashable
+    
 	func makePresentable(for navigationItem: Item) -> Presentable
 }
 

--- a/Tests/ComposableNavigationTests/ModalNavigationTests.swift
+++ b/Tests/ComposableNavigationTests/ModalNavigationTests.swift
@@ -3,8 +3,8 @@ import XCTest
 import ComposableArchitecture
 @testable import ComposableNavigation
 
+@MainActor
 class ModalNavigationTests: XCTestCase {
-	@MainActor
 	func testPresentingFullScreenItem() async {
 		let store = makeStore(.init(styledItem: nil))
 		
@@ -13,7 +13,6 @@ class ModalNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testPresentingSheetItem() async {
 		let store = makeStore(.init(styledItem: nil))
 		
@@ -22,7 +21,6 @@ class ModalNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testSettingModalItem() async {
 		let store = makeStore(.init(styledItem: nil))
 		
@@ -31,7 +29,6 @@ class ModalNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testDismissingItem() async {
 		let store = makeStore(.init(styledItem: .init(item: 1, style: .pageSheet)))
 		
@@ -40,7 +37,6 @@ class ModalNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testDismissingWithoutItem() async {
 		let store = makeStore(.init(styledItem: nil))
 		store.exhaustivity = .off
@@ -50,7 +46,6 @@ class ModalNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testChangingStyle() async {
 		let store = makeStore(.init(styledItem: .init(item: 1, style: .pageSheet)))
 		
@@ -59,7 +54,6 @@ class ModalNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testChangingItem() async {
 		let store = makeStore(.init(styledItem: .init(item: 1, style: .pageSheet)))
 		
@@ -68,7 +62,6 @@ class ModalNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testDisablingAnimation() async {
 		let store = makeStore(.init(styledItem: nil))
 		

--- a/Tests/ComposableNavigationTests/StackNavigationTests.swift
+++ b/Tests/ComposableNavigationTests/StackNavigationTests.swift
@@ -3,8 +3,8 @@ import XCTest
 import ComposableArchitecture
 @testable import ComposableNavigation
 
+@MainActor
 class StackNavigationTests: XCTestCase {
-	@MainActor
 	func testPushItem() async {
 		let store = makeStore(.init(items: []))
 		
@@ -13,7 +13,6 @@ class StackNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testPushItemOnExistingStack() async {
 		let store = makeStore(.init(items: [1, 2]))
 		
@@ -22,7 +21,6 @@ class StackNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testPushItems() async {
 		let store = makeStore(.init(items: []))
 		
@@ -31,7 +29,6 @@ class StackNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testPushItemsOnExistingStack() async {
 		let store = makeStore(.init(items: [1, 2]))
 		
@@ -40,7 +37,6 @@ class StackNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testPopItem() async {
 		let store = makeStore(.init(items: [1, 2]))
 		
@@ -49,7 +45,6 @@ class StackNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testPopItemsCount() async {
 		let store = makeStore(.init(items: [1, 2, 3]))
 		
@@ -58,21 +53,18 @@ class StackNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testPopItemFromEmptyStack() async {
 		let store = makeStore(.init(items: []))
 		
 		await store.send(.popItem())
 	}
 	
-	@MainActor
 	func testPopTooManyItems() async {
 		let store = makeStore(.init(items: [1, 2]))
 		
 		await store.send(.popItems(count: 5))
 	}
 	
-	@MainActor
 	func testPopToRoot() async {
 		let store = makeStore(.init(items: [1, 2, 3]))
 		
@@ -81,21 +73,18 @@ class StackNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testPopToRootOnEmptyStack() async {
 		let store = makeStore(.init(items: []))
 		
 		await store.send(.popToRoot())
 	}
 	
-	@MainActor
 	func testPopToRootWithOnlyRoot() async {
 		let store = makeStore(.init(items: [1]))
 		
 		await store.send(.popToRoot())
 	}
 	
-	@MainActor
 	func testSetItems() async {
 		let store = makeStore(.init(items: [1, 2]))
 		
@@ -104,7 +93,6 @@ class StackNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testSetItemsFromEmpty() async {
 		let store = makeStore(.init(items: []))
 		
@@ -113,7 +101,6 @@ class StackNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testSetSameItemsDifferentOrder() async {
 		let store = makeStore(.init(items: [1, 2, 3]))
 		
@@ -122,7 +109,6 @@ class StackNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testDisablingAnimation() async {
 		let store = makeStore(.init(items: [1, 2]))
 		
@@ -131,7 +117,6 @@ class StackNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testDisablingAnimationAndSettingsItems() async {
 		let store = makeStore(.init(items: [1, 2]))
 		

--- a/Tests/ComposableNavigationTests/StoreCompactMapTest.swift
+++ b/Tests/ComposableNavigationTests/StoreCompactMapTest.swift
@@ -2,6 +2,7 @@ import XCTest
 import ComposableArchitecture
 @testable import ComposableNavigation
 
+@MainActor
 class StoreCompactMapTest: XCTestCase {
 	func testCompactMapNonOptional() throws {
 		let store = Store<Int?, Void>(initialState: 12, reducer: { EmptyReducer() })

--- a/Tests/ComposableNavigationTests/TabNavigationTests.swift
+++ b/Tests/ComposableNavigationTests/TabNavigationTests.swift
@@ -3,8 +3,8 @@ import XCTest
 import ComposableArchitecture
 @testable import ComposableNavigation
 
+@MainActor
 class TabNavigationTests: XCTestCase {
-	@MainActor
 	func testSetActiveItem() async {
 		let store = makeStore(.init(items: [1, 2, 3], activeItem: 1))
 		
@@ -13,14 +13,12 @@ class TabNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testSetActiveItemOutOfBounds() async {
 		let store = makeStore(.init(items: [1, 2, 3], activeItem: 1))
 		
 		await store.send(.setActiveItem(99))
 	}
 	
-	@MainActor
 	func testSetActiveIndex() async {
 		let store = makeStore(.init(items: [1, 2, 3], activeItem: 1))
 		
@@ -29,14 +27,12 @@ class TabNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testSetActiveIndexOutOfBounds() async {
 		let store = makeStore(.init(items: [1, 2, 3], activeItem: 1))
 		
 		await store.send(.setActiveIndex(99))
 	}
 	
-	@MainActor
 	func testSetItems() async {
 		let store = makeStore(.init(items: [1, 2], activeItem: 1))
 		
@@ -45,7 +41,6 @@ class TabNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testSetItemsFromEmpty() async {
 		let store = makeStore(.init(items: [], activeItem: 1))
 		
@@ -54,7 +49,6 @@ class TabNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testSetSameItemsDifferentOrder() async {
 		let store = makeStore(.init(items: [1, 2, 3], activeItem: 1))
 		
@@ -63,7 +57,6 @@ class TabNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testDisablingAnimation() async {
 		let store = makeStore(.init(items: [1, 2], activeItem: 1))
 		
@@ -72,7 +65,6 @@ class TabNavigationTests: XCTestCase {
 		}
 	}
 	
-	@MainActor
 	func testDisablingAnimationAndSettingsItems() async {
 		let store = makeStore(.init(items: [1, 2], activeItem: 1))
 		


### PR DESCRIPTION
I migrated to Swift 6 since Xcode 26 will be mandatory soon. I fixed some warnings and added missing `Sendable` conformance.