### PR TITLE
Set minimal iOS version to 16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
 	name: "ComposableNavigation",
-	platforms: [.iOS(.v13)],
+	platforms: [.iOS(.v16)],
 	products: [
 		.library(
 			name: "ComposableNavigation",


### PR DESCRIPTION
With `swift-composable-architecture` `1.24.0` the minimum iOS version was raised from 13 to 16. In order to use the latest TCA releases we need ComposableNavigation to do the same.